### PR TITLE
Adding Linux Example Files

### DIFF
--- a/scr/Linux/discordSend.py
+++ b/scr/Linux/discordSend.py
@@ -1,0 +1,115 @@
+# Import libraries for HTTP requests, processing EXE output, and getting parameter values passed from our caller script (in VisualSVN)
+import requests
+import subprocess
+import sys
+import os.path
+
+# Discord has a message length limit of 2000 characters, so we need to set some maximum string length limits
+MAX_LENGTH_LOG = 200
+MAX_LENGTH_CHANGELIST = 1700
+
+# Base name to give our bot that'll post the payload message
+botusernamebase = "SVN"
+
+# URL of image to use for our bot's avatar (I recommend hosting this image elsewhere like AWS)
+botavatarurl = "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f4/Antu_smartsvn.svg/1200px-Antu_smartsvn.svg.png"
+
+# Root directory in which the repositories are stored
+reporootdir = "/svn/data/repositories/"    # CHANGE THIS TO POINT TO YOUR REPOSITORY ROOT DIRECTORY
+
+# Local file path of svnlook.exe, which is used to get the commit's author, log, and changelist
+svnlook = "/opt/CollabNet_Subversion/bin/svnlook"    # CHANGE THIS TO POINT TO YOUR SVNLOOK.EXE PATH
+
+# URL of webhook to which we'll send our payload
+webhookurl = sys.argv[3]
+
+# Revision number of the commit
+revision = sys.argv[1]
+
+# Name of the repository that was committed to
+reponame = os.path.basename(sys.argv[2])
+
+# Name of the location that was committed to
+location = sys.argv[4]
+
+# Assemble the repository's file path
+repopath = "{0}{1}".format(reporootdir, reponame)
+
+# Get the commit's author with svnlook
+process_author = subprocess.Popen([svnlook, "author", repopath, "-r", revision], stdout=subprocess.PIPE)
+author, author_err = process_author.communicate()
+
+# Get the commit message with svnlook
+process_log = subprocess.Popen([svnlook, "log", repopath, "-r", revision], stdout=subprocess.PIPE)
+loglong, loglong_err = process_log.communicate()
+
+# Set default message for when there's no commit message
+if loglong.decode().isspace():
+	log_decoded = True
+	loglong = "<no commit message>"
+else:
+	log_decoded = False
+
+# Get the commit's changelist with svnlook
+# process_changelist = subprocess.Popen([svnlook, "changed", repopath, "-r", revision], stdout=subprocess.PIPE)
+# changelistlong, changelistlong_err = process_changelist.communicate()
+
+# Set default message for when there's (somehow) no changelist
+# if changelistlong.decode().isspace():
+#	changelist_decoded = True
+#	changelistlong = "<no changelist>"
+#else:
+#	changelist_decoded = False
+
+
+# Prune the new lines from the endings
+author = author.strip()
+loglong = loglong.strip()
+# changelistlong = changelistlong.strip()
+
+
+# Truncate end of log if it exceeds max length
+if (len(loglong) > (MAX_LENGTH_LOG - 6)):
+	log_decoded = True
+	logparsed = loglong[0:(MAX_LENGTH_LOG - 6)]
+	log = "{0} <...>".format(logparsed.decode())
+else:
+	log = loglong
+
+# Truncate end of changelist if it exceeds max length
+#if (len(changelistlong) > (MAX_LENGTH_CHANGELIST - 6)):
+#	changelist_decoded = True
+#	changelistparsed = changelistlong[0:(MAX_LENGTH_CHANGELIST - 6)]
+#	changelist = "{0} <...>".format(changelistparsed.decode())
+#else:
+#	changelist = changelistlong
+
+
+# Do some last-minute pruning for good measure
+reponame = reponame.strip()
+revision = revision.strip()
+author = author.decode()
+
+# Decode the log and changelist if they haven't been already
+if not log_decoded:
+	log = log.decode()
+#if not changelist_decoded:
+#	changelist = changelist.decode()
+
+
+# Assemble our bot's username based on the base name and the author who made the commit (e.g., "Aaron (Subversion)")
+botusername = "{0} ({1})".format(author, botusernamebase)
+
+# Assemble our message to include in the payload
+message = "**{0}:**  Revision {1} committed to {4} by {2}:\n```{3}```".format(reponame, revision, author, log, location)
+
+# Construct our payload to send to the webhook
+payload = {
+	'username': botusername,
+	'avatar_url': botavatarurl,
+	'content': message
+}
+
+# Send our payload to the webhook with an HTTP POST request
+r = requests.post(webhookurl, data=payload)
+print(r.status_code, r.reason)

--- a/scr/Linux/post-commit
+++ b/scr/Linux/post-commit
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+# POST-COMMIT HOOK
+#
+# The post-commit hook is invoked after a commit.  Subversion runs
+# this hook by invoking a program (script, executable, binary, etc.)
+# named 'post-commit' (for which this file is a template) with the 
+# following ordered arguments:
+#
+#   [1] REPOS-PATH   (the path to this repository)
+#   [2] REV          (the number of the revision just committed)
+#   [3] TXN-NAME     (the name of the transaction that has become REV)
+#
+# The default working directory for the invocation is undefined, so
+# the program should set one explicitly if it cares.
+#
+# Because the commit has already completed and cannot be undone,
+# the exit code of the hook program is ignored.  The hook program
+# can use the 'svnlook' utility to help it examine the
+# newly-committed tree.
+#
+# On a Unix system, the normal procedure is to have 'post-commit'
+# invoke other programs to do the real work, though it may do the
+# work itself too.
+#
+# Note that 'post-commit' must be executable by the user(s) who will
+# invoke it (typically the user httpd runs as), and that user must
+# have filesystem-level permission to access the repository.
+#
+# On a Windows system, you should name the hook program
+# 'post-commit.bat' or 'post-commit.exe',
+# but the basic idea is the same.
+# 
+# The hook program typically does not inherit the environment of
+# its parent process.  For example, a common problem is for the
+# PATH environment variable to not be set to its usual value, so
+# that subprograms fail to launch unless invoked via absolute path.
+# If you're having unexpected problems with a hook program, the
+# culprit may be unusual (or missing) environment variables.
+# 
+# Here is an example hook script, for a Unix /bin/sh interpreter.
+# For more examples and pre-written hooks, see those in
+# the Subversion repository at
+# http://svn.apache.org/repos/asf/subversion/trunk/tools/hook-scripts/ and
+# http://svn.apache.org/repos/asf/subversion/trunk/contrib/hook-scripts/
+
+REPOS="$1"
+REV="$2"
+TXN_NAME="$3"
+WEBHOOK_URL="YOUR WEBHOOK URL HERE"
+WEBHOOK_PATH="/<YOUR REPO DIRECTORY>/hooks/discordSend.py"
+PYTHON_PATH="/usr/bin/python3.6"
+LOCATION="trunk"
+
+# Filter all commits so the webhook only sends messages when Trunk is committed to. If you want it to notify ALL SVN commits, then delete the whole IF statement below
+if /opt/CollabNet_Subversion/bin/svnlook changed $REPOS -r $REV | grep -i trunk
+then
+	$PYTHON_PATH $WEBHOOK_PATH "$REV" "$REPOS" "$WEBHOOK_URL" "$LOCATION"
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
These example files show how to format the post-commit webhook in an SVN installation on a Linux machine. This was used specifically on a CentOS 7 Linux machine with SmartSVN installed.